### PR TITLE
Issue #1: Lump together the random effect and expected counts

### DIFF
--- a/inst/stan/functions/calc_exp_total_obs.stan
+++ b/inst/stan/functions/calc_exp_total_obs.stan
@@ -1,0 +1,28 @@
+/**
+ * Mean value of the total counts
+ *
+ * Multiplies the mean value of the total observation by the random effect.
+ * Only for the NegBin2M and NegBin2M models. For the rest of the models, the
+ * mean value remains unchanged.
+ *
+ * @param lambda Expected value of the total observations without the random
+ * effect, an array of reals.
+ *
+ * @param random_effect multiplicative random effect, used only for the NegBin2M
+ * and NegBin1M models, a vector of the same length as `lambda`
+ *
+ * @param model_obs Indicator of the model used (0 for Poisson, 1 for NegBinX,
+ * 2 for NegBin2D, 3 for NegBin1D, 4 for NegBin2M and 5 for NegBin1M).
+ *
+ * @return The expectation of the total
+ **/
+array[] real calc_exp_total_obs(array[] real lambda, vector random_effect, int model_obs) {
+  int n = num_elements(lambda);
+  array[n] real exp_total_obs;
+  if (model_obs == 4 || model_obs == 5) {
+    exp_total_obs = multiply_array(random_effect, lambda);
+  } else {
+    exp_total_obs = lambda;
+  }
+  return(exp_total_obs);
+}

--- a/inst/stan/functions/calc_re_parametres.stan
+++ b/inst/stan/functions/calc_re_parametres.stan
@@ -1,3 +1,22 @@
+/**
+ * Calculate the parameters of the random effect distribution
+ *
+ * Calculates the parameters, which enter as the shape and rate of the gamma
+ * distribution of the random effects needed for the NegBin2M and NegBin1M
+ * observation model.
+ *
+ * @param lambda Expected value of the total observations, an array of reals.
+ *
+ * @param nb_size Size = (1 / Dispersion parameter) for the negative binomial
+ * model, a vector of size 0 for Poisson (being ignored), size 1 for the
+ * negative binomial models
+ *
+ * @param model_obs Indicator of the model used (0 for Poisson, 1 for NegBinX,
+ * 2 for NegBin2D, 3 for NegBin1D, 4 for NegBin2M and 5 for NegBin1M).
+ *
+ * @return Array of the random effect distribution parameters, same length as
+ * the expected value of the total observations.
+ **/
 array[] real calc_re_parameters(array[] real lambda, vector nb_size, int model_obs) {
   int n = num_elements(lambda);
   array[n] real re_params;

--- a/inst/stan/functions/calc_re_parametres.stan
+++ b/inst/stan/functions/calc_re_parametres.stan
@@ -1,0 +1,10 @@
+array[] real calc_re_parameters(array[] real lambda, vector nb_size, int model_obs) {
+  int n = num_elements(lambda);
+  array[n] real re_params;
+  if (model_obs == 4) {
+    re_params = rep_array(nb_size[1], n);
+  } else if (model_obs == 5) {
+    re_params = multiply_array(nb_size[1], lambda);
+  }
+  return(re_params);
+}

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -1,14 +1,14 @@
 /**
  * Observation likelihood
- * 
+ *
  * Computes the log probability mass function (LPMF) for observations according
- * to the 6 observational models. 
- * 
+ * to the 6 observational models.
+ *
  * @param obs Observations, an array of integers.
  *
  * @param lambdas Expected observations of the total, an array of reals.
  *
- * @param nb_size Size = (1 / Dispersion parameter) for the negative binomial 
+ * @param nb_size Size = (1 / Dispersion parameter) for the negative binomial
  * model, a vector of size 0 for Poisson (being ignoed), size 1 for the negative
  * binomial models
  *
@@ -21,42 +21,36 @@
  * 2 for NegBin2D, 3 for NegBin1D, 4 for NegBin2M and 5 for NegBin1M).
  *
  * @param P,p arrays of lookup variables
- * 
+ *
  * @return The log probability mass of the observations under the specified
  * model.
- * 
+ *
  * @note The function selects between the negative binomial models and the
  * Poisson model based on the `model_obs` flag. It uses
  * `neg_binomial_2_lpmf` for the negative binomial models and
  * `poisson_lpmf` for the Poisson model.
  */
-real obs_lpmf(array[] int obs, array[] real lambda, vector nb_size,
-                  vector reporting_delay, vector random_effect,
-                  int model_obs, array[] int P, array[] int p) {
+real obs_lpmf(array[] int obs, array[] real exp_obs, vector nb_size,
+                  vector reporting_delay, int model_obs, array[] int P,
+                  array[] int p) {
    real tar = 0;
    int m = num_elements(obs);
-   int n = num_elements(lambda);
-   array[m] real exp_obs = observe_onsets_with_delay(lambda, reporting_delay, P, p);
-   
-   if (model_obs == 0) {  
-     // Poisson
+   int n = num_elements(p);
+
+   if (model_obs == 0 || model_obs == 4 || model_obs == 5) {
+     // Poisson, NegBin2M and NegBin1M
      tar = poisson_lpmf(obs | exp_obs);
-   } else if (model_obs == 1) {  
+   } else if (model_obs == 1) {
      // NegBinX
      tar = neg_binomial_2_lpmf(obs | exp_obs, nb_size[1]);
-   } else if (model_obs == 2) {  
+   } else if (model_obs == 2) {
      // NegBin2D
      array[m] real nb_size_expanded = observe_onsets_with_delay(rep_array(nb_size[1], n), reporting_delay, P, p);
      tar = neg_binomial_2_lpmf(obs | exp_obs, nb_size_expanded);
-   } else if (model_obs == 3) { 
+   } else if (model_obs == 3) {
      // NegBin1D
      array[m] real nb_size_expanded = multiply_array(nb_size[1], exp_obs);
      tar = neg_binomial_2_lpmf(obs | exp_obs, nb_size_expanded);
-   } else if (model_obs == 4 || model_obs == 5) {  
-     // NegBin2M and NegBin1M: random effect reprezentation
-     array[n] real lambda_with_re = multiply_array(random_effect, lambda);
-     array[m] real exp_obs_with_re = observe_onsets_with_delay(lambda_with_re, reporting_delay, P, p);
-     tar = poisson_lpmf(obs | exp_obs_with_re);
    }
    return(tar);
 }

--- a/inst/stan/functions/obs_lpmf.stan
+++ b/inst/stan/functions/obs_lpmf.stan
@@ -6,16 +6,13 @@
  *
  * @param obs Observations, an array of integers.
  *
- * @param lambdas Expected observations of the total, an array of reals.
+ * @param exp_obs Expectations of the partial counts, an array of reals.
  *
  * @param nb_size Size = (1 / Dispersion parameter) for the negative binomial
- * model, a vector of size 0 for Poisson (being ignoed), size 1 for the negative
- * binomial models
+ * model, a vector of size 0 for Poisson (being ignored), size 1 for the
+ * negative binomial models
  *
  * @param reporting_delay reporting delay probability, a vector
- *
- * @param random_effect multiplicative random effect, used only for the NegBin2M
- * and NegBin1M models, a vector of the same length as `lambda`
  *
  * @param model_obs Indicator of the model used (0 for Poisson, 1 for NegBinX,
  * 2 for NegBin2D, 3 for NegBin1D, 4 for NegBin2M and 5 for NegBin1M).
@@ -27,8 +24,8 @@
  *
  * @note The function selects between the negative binomial models and the
  * Poisson model based on the `model_obs` flag. It uses
- * `neg_binomial_2_lpmf` for the negative binomial models and
- * `poisson_lpmf` for the Poisson model.
+ * `neg_binomial_2_lpmf` for NegBinX, NegBin2D and NegBin1D models and
+ * `poisson_lpmf` for the Poisson, NegBin2M and NegBin1M models.
  */
 real obs_lpmf(array[] int obs, array[] real exp_obs, vector nb_size,
                   vector reporting_delay, int model_obs, array[] int P,

--- a/inst/stan/functions/predict_rng.stan
+++ b/inst/stan/functions/predict_rng.stan
@@ -1,27 +1,22 @@
-array[] int predict_rng(array[] real lambda, vector nb_size, 
-                          vector reporting_delay, vector random_effect, 
-                          int model_obs, array[] int P, array[] int p, int d, 
+array[] int predict_rng(array[] real exp_obs, vector nb_size,
+                          vector reporting_delay,
+                          int model_obs, array[] int P, array[] int p, int d,
                           array[] int D) {
   // Prepare the expected values and the neg. binom sizes
   int n = num_elements(p);
   int n_predict = d * n - sum(p);
-  array[n*d] real exp_obs = observe_onsets_with_delay(lambda, reporting_delay, D, rep_array(d, n));
   array[n*d] real nb_size_expanded;
-  if (model_obs == 1) {  
+  if (model_obs == 1) {
     // NegBinX
     nb_size_expanded = rep_array(nb_size[1], d*n);
-  } else if (model_obs == 2) {  
+  } else if (model_obs == 2) {
     // NegBin2D
     nb_size_expanded = observe_onsets_with_delay(rep_array(nb_size[1], n), reporting_delay, D, rep_array(d, n));
-  } else if (model_obs == 3) { 
+  } else if (model_obs == 3) {
     // NegBin1D
     nb_size_expanded = multiply_array(nb_size[1], exp_obs);
-  } else if (model_obs == 4 || model_obs == 5) {  
-    // NegBin2M and NegBin1M: random effect reprezentation
-    array[n] real lambda_with_re = multiply_array(random_effect, lambda);
-    exp_obs = observe_onsets_with_delay(lambda_with_re, reporting_delay, D, rep_array(d, n));
   }
-  
+
   // Sample the predictions
   array[n_predict] int predicted_counts;
   int predicted_index = 0;
@@ -41,9 +36,9 @@ array[] int predict_rng(array[] real lambda, vector nb_size,
             );
         } else {
           predicted_counts[predicted_index + j] = neg_binomial_2_rng(
-              exp_obs[D_index + p[i] + j], 
+              exp_obs[D_index + p[i] + j],
               nb_size_expanded[D_index + p[i] + j]
-            ); 
+            );
         }
       }
       predicted_index += missing_reports;

--- a/inst/stan/nowcast.stan
+++ b/inst/stan/nowcast.stan
@@ -33,10 +33,21 @@ parameters {
 
 transformed parameters {
   array[n] real lambda = geometric_random_walk(init_onsets, rw_noise, rw_sd);
-  array[n] real lambda_times_nb_size = rep_array(1, n);
-  if (model_obs == 5) {
-    lambda_times_nb_size = multiply_array(nb_size[1], lambda);
+  array[n] real re_params;
+  if (model_obs == 4) {
+    re_params = rep_array(nb_size[1], n);
+  } else if (model_obs == 5) {
+    re_params = multiply_array(nb_size[1], lambda);
   }
+  // multiply lambda by the random effect, when needed
+  array[n] real exp_total_obs;
+  if (model_obs == 4 || model_obs == 5) {
+    exp_total_obs = multiply_array(random_effect, lambda);
+  } else {
+    exp_total_obs = lambda;
+  }
+  array[m] real exp_obs = observe_onsets_with_delay(exp_total_obs, reporting_delay, P, p);
+  array[d*n] real exp_obs_complete = observe_onsets_with_delay(exp_total_obs, reporting_delay, D, rep_array(d, n));
 }
 
 model {
@@ -47,18 +58,16 @@ model {
   reporting_delay ~ dirichlet(rep_vector(1, d));
   nb_size ~ normal(1, 3) T[0, ];
   // Random effect for the NegBin1M and NegBin2M models
-  if (model_obs == 4) {
-    random_effect ~ gamma(nb_size[1], nb_size[1]);
-  } else if (model_obs == 5) {
-    random_effect ~ gamma(lambda_times_nb_size, lambda_times_nb_size);
+  if (model_obs == 4 || model_obs == 5) {
+    random_effect ~ gamma(re_params, re_params);
   }
   // Likelihood
-  obs ~ obs(lambda, nb_size, reporting_delay, random_effect, model_obs, P, p);
+  obs ~ obs(exp_obs, nb_size, reporting_delay, model_obs, P, p);
 }
 
 generated quantities {
   array[d * n - m] int predicted_counts = predict_rng(
-      lambda, nb_size, reporting_delay, random_effect, model_obs, P, p, d, D
+      exp_obs_complete, nb_size, reporting_delay, model_obs, P, p, d, D
      );
   array[n] int nowcast = combine_obs_with_predicted_obs(
       obs, predicted_counts, P, p, d, D

--- a/inst/stan/nowcast.stan
+++ b/inst/stan/nowcast.stan
@@ -4,6 +4,8 @@ functions {
   #include "functions/predict_rng.stan"
   #include "functions/combine_obs_with_predicted_obs.stan"
   #include "functions/multiply_array.stan"
+  #include "functions/calc_exp_total_obs.stan"
+  #include "functions/calc_re_parametres.stan"
   #include "functions/obs_lpmf.stan"
 }
 
@@ -33,19 +35,9 @@ parameters {
 
 transformed parameters {
   array[n] real lambda = geometric_random_walk(init_onsets, rw_noise, rw_sd);
-  array[n] real re_params;
-  if (model_obs == 4) {
-    re_params = rep_array(nb_size[1], n);
-  } else if (model_obs == 5) {
-    re_params = multiply_array(nb_size[1], lambda);
-  }
+  array[n] real re_params = calc_re_parameters(lambda, nb_size, model_obs);
   // multiply lambda by the random effect, when needed
-  array[n] real exp_total_obs;
-  if (model_obs == 4 || model_obs == 5) {
-    exp_total_obs = multiply_array(random_effect, lambda);
-  } else {
-    exp_total_obs = lambda;
-  }
+  array[n] real exp_total_obs = calc_exp_total_obs(lambda, random_effect, model_obs);
   array[m] real exp_obs = observe_onsets_with_delay(exp_total_obs, reporting_delay, P, p);
   array[d*n] real exp_obs_complete = observe_onsets_with_delay(exp_total_obs, reporting_delay, D, rep_array(d, n));
 }


### PR DESCRIPTION
This PR closes #1. It simplifies the `obs_lpmf` and `predict_rng` functions by putting together `lambda` and `random_effect` early on in the `nowcast.stan` model.

The code does not currently pass the snapshot test for NegBin2M locally. Is it because of the ordering of random (and possibly other) operations?